### PR TITLE
Fixing a typo

### DIFF
--- a/week2/class_exercises.md
+++ b/week2/class_exercises.md
@@ -21,7 +21,7 @@ The workflow is the same that the students will use during the final project.
  9. push `feature/fruits` to github
  10. create pull request to merge `feature/fruits` into `master`
 
-**Note**: the students will get a merge conflict on step 9.
+**Note**: the students will get a merge conflict on step 8.
 
 
 ### Exercise 2:


### PR DESCRIPTION
In Week 2 Exercise 1, the merging conflict will be caused by step 8.

Besides that, it seems to be expected that students should pull recent changes from the remote main branch into their local feature branch. This is not recomended. A git rebase is more preferable and a cleaner solution.