### PR TITLE
Lesson materials

### DIFF
--- a/Git1/lesson_plan.md
+++ b/Git1/lesson_plan.md
@@ -4,7 +4,7 @@
 These are some examples of previously created materials by mentors that you can use yourself, or for inspiration.
 - [Introduction to Git](https://radical-somersault-80b.notion.site/Introduction-to-Git-184dc1cafb9480ffad0de16e6ea8b379) (by [@aina21](https://www.github.com/aina21), Team 31)
 
-
+## Lesson outline
 This lesson plan is meant for a traditional class (vs. flipped classroom) where the mentor teaches the contents with breaks for exercises.
 The material to be taught is the same as in the flipped classroom though.
 The exercises suggested for the flipped classroom can be found [here](./class_exercises.md).

--- a/Git1/lesson_plan.md
+++ b/Git1/lesson_plan.md
@@ -2,7 +2,7 @@
 
 ## Lesson materials
 These are some examples of previously created materials by mentors that you can use yourself, or for inspiration.
-- [Introduction to Git]([Introduction to Git](https://radical-somersault-80b.notion.site/Introduction-to-Git-184dc1cafb9480ffad0de16e6ea8b379)) (by [@aina21] (https://www.github.com/aina21 on Team 31)
+- [Introduction to Git](https://radical-somersault-80b.notion.site/Introduction-to-Git-184dc1cafb9480ffad0de16e6ea8b379) (by [@aina21](https://www.github.com/aina21), Team 31)
 
 
 This lesson plan is meant for a traditional class (vs. flipped classroom) where the mentor teaches the contents with breaks for exercises.

--- a/Git1/lesson_plan.md
+++ b/Git1/lesson_plan.md
@@ -1,5 +1,10 @@
 # Lesson plan
 
+## Lesson materials
+These are some examples of previously created materials by mentors that you can use yourself, or for inspiration.
+- [Introduction to Git]([Introduction to Git](https://radical-somersault-80b.notion.site/Introduction-to-Git-184dc1cafb9480ffad0de16e6ea8b379)) (by [@aina21] (https://www.github.com/aina21 on Team 31)
+
+
 This lesson plan is meant for a traditional class (vs. flipped classroom) where the mentor teaches the contents with breaks for exercises.
 The material to be taught is the same as in the flipped classroom though.
 The exercises suggested for the flipped classroom can be found [here](./class_exercises.md).


### PR DESCRIPTION
I propose we add a "materials" section to our lesson plans, so we can add slides, docs and other materials that mentors create as part of teaching the session.

Two reasons:
1. Share knowledge between mentors (especially new ones who join!)
2. Create a single, transparent place to store materials (instead of getting lost in team channels)

My idea is that they are shared here mostly for inspiration, but mentors could very well just use some previous materials instead of having to create their own.

Note: "Lessons" should now be called "Sessions" ([source](https://mentor.hackyourfuture.dk/master/glossary#session)) but since that would trigger a lot of language updates in this whole repo I'm leaving it out for now. 